### PR TITLE
Minor revisions to cloudwatch-to-splunk lambda

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "disable_subscription_filter" {
 # Use cloudwatch_to_splunk lambda function by default.
 variable "function_name" {
   description = "Name of the lambda function to be invoked by the filter"
-  default     = "cloudwatch_to_splunk"
+  default     = "cloudwatch-to-splunk"
 }
 
 variable "filter_pattern" {


### PR DESCRIPTION
*   Change default function name from underscores to hyphens to be
    consistent with other lambda functions we've deployed.