### PR TITLE
Need to create SSM variables for cloudwatch-to-splunk function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 Provides a CloudWatch Log Group resource. By default a [subscription
 filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs//Subscriptions.html)
-is provided that forwards all of the log group's data to
-the Lambda function
-[cloudwatch-to-splunk](https://github.com/techservicesillinois/terraform-aws-cloudwatch-to-splunk).
+is provided that forwards all of the log group's data to the
+[cloudwatch-to-splunk](https://github.com/techservicesillinois/terraform-aws-cloudwatch-to-splunk) lambda function. If the subscription filter is enabled (the default), provide [the three SSM parameter store variables](https://github.com/techservicesillinois/splunk-aws-serverless-apps/tree/master/splunk-cloudwatch-logs-processor) required by the lambda function. Values for these variables will normally be set in the AWS console. If `disable_subscription_filter` is set, these variables are not provided.
 
 Argument Reference
 -----------------

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,0 +1,35 @@
+locals {
+  parameters = (var.disable_subscription_filter) ? {} : {
+    "hec_endpoint" = {
+      description = "Splunk HEC endpoint (cloudwatch-to-splunk for log group ${var.name})"
+      type        = "String"
+    }
+
+    "hec_token" = {
+      description = "Splunk HEC token (cloudwatch-to-splunk for log group ${var.name})"
+      type        = "SecureString"
+    }
+
+    "sourcetype" = {
+      description = "Splunk sourcetype (cloudwatch-to-splunk for log group ${var.name})"
+      type        = "String"
+    }
+  }
+}
+
+# This code adapted from git@github.com:techservicesillinois/terraform-aws-ssm-parameter.
+
+resource "aws_ssm_parameter" "default" {
+  for_each    = local.parameters
+  name        = format("/%s", join("/", compact(split("/", format("%s/%s/%s", var.prefix, var.name, each.key)))))
+  type        = lookup(each.value, "type", "String")
+  value       = lookup(each.value, "value", "*** NO VALUE SET ***")
+  description = lookup(each.value, "description", "*** NO DESCRIPTION SET ***")
+
+  lifecycle {
+    # Never update the value of an existing SSM parameter.
+    ignore_changes = [value]
+    # Protect people from themselves.
+    prevent_destroy = true
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,17 @@ variable "name" {
   description = "Log group name"
 }
 
+variable "parameters" {
+  description = "Parameters expressed as a map of maps. Each map's key is its intended SSM parameter name, and the value stored under that key is another map that may contain the following keys: description, type, and value. Default values are supplied for default cloudwatch-to-splunk lambda function"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "prefix" {
+  description = "Prefix prepended to parameter name if not using default"
+  default     = "/cloudwatch_to_splunk"
+}
+
 variable "retention" {
   description = "Log retention period in days"
   type        = number


### PR DESCRIPTION
We apparently never wrote code to create the three SSM parameters needed by the cloudwatch-to-splunk lambda function.