### PR TITLE
Fix error when cloudfront-to-lambda doesn't exist

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,5 +3,5 @@ output "arn" {
 }
 
 output "lambda_function_arn" {
-  value = data.aws_lambda_function.selected.qualified_arn
+  value = var.disable_subscription_filter ? null : data.aws_lambda_function.selected[0].qualified_arn
 }

--- a/subscription-filter.tf
+++ b/subscription-filter.tf
@@ -8,13 +8,14 @@ data "aws_region" "current" {}
 
 # Get lambda function name and ARN.
 data "aws_lambda_function" "selected" {
+  count         = var.disable_subscription_filter ? 0 : 1
   function_name = local.function_name
 }
 
 resource "aws_lambda_permission" "default" {
   count         = var.disable_subscription_filter ? 0 : 1
   action        = "lambda:InvokeFunction"
-  function_name = data.aws_lambda_function.selected.function_name
+  function_name = data.aws_lambda_function.selected[0].function_name
   principal     = local.principal
   source_arn    = format("%s:*", aws_cloudwatch_log_group.default.arn)
 }
@@ -24,6 +25,6 @@ resource "aws_cloudwatch_log_subscription_filter" "default" {
   name            = "filter"
   log_group_name  = aws_cloudwatch_log_group.default.name
   filter_pattern  = var.filter_pattern
-  destination_arn = data.aws_lambda_function.selected.arn
+  destination_arn = data.aws_lambda_function.selected[0].arn
   depends_on      = [aws_lambda_permission.default]
 }


### PR DESCRIPTION
Fix problem wherein this module fails if the caller attempts to disable the subscription filter if the cloudfront-to-splunk lambda function doesn't exist. This was the result of a data source not having a `count`, causing the lambda function to be looked up even when it wasn't needed (such as in the development account).